### PR TITLE
fix grid, octree: faster point distribution

### DIFF
--- a/octreelib/grid/grid.py
+++ b/octreelib/grid/grid.py
@@ -79,7 +79,10 @@ class Grid(GridBase):
             voxel_indices, axis=0, return_inverse=True
         )
 
-        # Use numpy advanced indexing to group points by voxel
+        # Points are reordered based on the `point_inverse_indices`, so that they can be split
+        # into groups of points, where each group is inserted into the corresponding voxel.
+        # The indices for splitting are calculated using `np.cumsum()` based on the number
+        # of points which would be distributed into each voxel.
         grouped_points = np.split(
             points[point_inverse_indices.argsort()],
             np.cumsum(np.bincount(point_inverse_indices))[:-1],

--- a/octreelib/grid/grid.py
+++ b/octreelib/grid/grid.py
@@ -75,18 +75,20 @@ class Grid(GridBase):
         ).astype(int)
 
         # Create a unique identifier for each voxel based on its indices
-        unique_indices, inverse_indices = np.unique(
+        unique_voxel_indices, point_inverse_indices = np.unique(
             voxel_indices, axis=0, return_inverse=True
         )
 
         # Use numpy advanced indexing to group points by voxel
         grouped_points = np.split(
-            points[inverse_indices.argsort()],
-            np.cumsum(np.bincount(inverse_indices))[:-1],
+            points[point_inverse_indices.argsort()],
+            np.cumsum(np.bincount(point_inverse_indices))[:-1],
         )
 
         # Insert points to octrees
-        for voxel_coordinates, voxel_points in zip(unique_indices, grouped_points):
+        for voxel_coordinates, voxel_points in zip(
+            unique_voxel_indices, grouped_points
+        ):
             target_voxel = VoxelBase(
                 np.array(voxel_coordinates),
                 self._grid_config.voxel_edge_length,

--- a/octreelib/grid/grid.py
+++ b/octreelib/grid/grid.py
@@ -67,7 +67,7 @@ class Grid(GridBase):
         # Register pose
         self.__pose_voxel_coordinates[pose_number] = []
 
-        # Distribute points to voxels using numpy operations
+        # Distribute points to voxels
         voxel_indices = (
             (points - self._grid_config.corner) // self._grid_config.voxel_edge_length
         ) * self._grid_config.voxel_edge_length

--- a/octreelib/grid/grid.py
+++ b/octreelib/grid/grid.py
@@ -69,9 +69,10 @@ class Grid(GridBase):
 
         # Distribute points to voxels
         voxel_indices = (
-            (points - self._grid_config.corner) // self._grid_config.voxel_edge_length
-        ) * self._grid_config.voxel_edge_length
-        voxel_indices = voxel_indices.astype(int)
+            (points - self._grid_config.corner)
+            // self._grid_config.voxel_edge_length
+            * self._grid_config.voxel_edge_length
+        ).astype(int)
 
         # Create a unique identifier for each voxel based on its indices
         unique_indices, inverse_indices = np.unique(

--- a/octreelib/grid/grid.py
+++ b/octreelib/grid/grid.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import random
-from typing import List, Dict, Callable, Optional, Type
+from typing import List, Dict, Callable, Optional
 
 import k3d
 import numpy as np

--- a/octreelib/grid/grid.py
+++ b/octreelib/grid/grid.py
@@ -11,10 +11,8 @@ from octreelib.grid.grid_base import (
     GridVisualizationType,
     VisualizationConfig,
 )
-from octreelib.internal.typing import T
 from octreelib.internal.point import PointCloud
 from octreelib.internal.voxel import Voxel, VoxelBase
-from octreelib.octree import Octree, OctreeConfig
 
 __all__ = ["Grid", "GridConfig"]
 

--- a/octreelib/octree/octree.py
+++ b/octreelib/octree/octree.py
@@ -67,18 +67,21 @@ class OctreeNode(OctreeNodeBase):
         :param points: Points to insert.
         """
         if self._has_children:
-            # distribute points to children
+            # For all points calculate the child to insert in
             child_indices_for_points = (
                 (points - self.corner_min) // (self.edge_length / 2)
             ).astype(int)
             unique_indices, inverse_indices = np.unique(
                 child_indices_for_points, axis=0, return_inverse=True
             )
+
+            # Reorder and group points by the child to insert in
             grouped_points = np.split(
                 points[inverse_indices.argsort()],
                 np.cumsum(np.bincount(inverse_indices))[:-1],
             )
             for child_index, child_points in zip(unique_indices, grouped_points):
+                # Calculate the internal child id from its binary representation
                 child_internal_id = (
                     child_index[0] * 4 + child_index[1] * 2 + child_index[2]
                 )

--- a/octreelib/octree/octree.py
+++ b/octreelib/octree/octree.py
@@ -71,6 +71,8 @@ class OctreeNode(OctreeNodeBase):
             child_indices_for_points = (
                 (points - self.corner_min) // (self.edge_length / 2)
             ).astype(int)
+
+            # Create a unique identifier for each voxel based on its indices
             unique_indices, inverse_indices = np.unique(
                 child_indices_for_points, axis=0, return_inverse=True
             )

--- a/octreelib/octree/octree.py
+++ b/octreelib/octree/octree.py
@@ -77,7 +77,10 @@ class OctreeNode(OctreeNodeBase):
                 voxel_indices, axis=0, return_inverse=True
             )
 
-            # Reorder and group points by the voxel
+            # Points are reordered based on the `point_inverse_indices`, so that they can be split
+            # into groups of points, where each group is inserted into the corresponding voxel.
+            # The indices for splitting are calculated using `np.cumsum()` based on the number
+            # of points which would be distributed into each voxel.
             grouped_points = np.split(
                 points[point_inverse_indices.argsort()],
                 np.cumsum(np.bincount(point_inverse_indices))[:-1],


### PR DESCRIPTION
A new method of distributing points into voxels is used
1. The target voxel identifier is calculated for all points.
2. The unique identifiers are extracted.
3. Points are reordered based of the unique identifiers and split, to form groups of points, where each group is inserted into the corresponding voxel.
4. Points are inserted into voxels.
