### PR TITLE
[feat CudaRansac] Parallelize final mask computation. Use shared variables instead of global variables

### DIFF
--- a/octreelib/ransac/cuda_ransac.py
+++ b/octreelib/ransac/cuda_ransac.py
@@ -124,7 +124,7 @@ class CudaRansac:
             # for all hypotheses
             best_plane = cuda.shared.array(shape=4, dtype=nb.float32)
             max_inliers_number = cuda.shared.array(shape=1, dtype=nb.int32)
-            # this mutex is needed to make sure that only one thread writes to the mask
+            # this mutex is needed to make sure that only one thread writes the best plane
             mutex = cuda.shared.array(shape=1, dtype=nb.int32)
             if thread_id == 0:
                 max_inliers_number[0] = 0


### PR DESCRIPTION
This PR speeds up RANSAC by 1) parallelising result mask computation, 2) using local variables that are shared between threads instead of global variables. 

1) Currently the result of the kernel (the result mask) is written by only one thread. The mask may be large, so it can be slow. In this PR the thread with the best plane writes the plane to the shared memory and all of the threads compute the mask based on the distance from points to the plane. 
2) It is inefficient to use global CUDA memory, as it is slower than shared memory (it is shared between threads of the same block). The variables `mask_mutex` and `max_inliers_number_cuda` are no longer passed to CUDA global memory, and are replaced with variables in the shared memory. 

Processing time comparison:
```
Clouds  Current (s)    New (s)
10       1.205917     1.126165
20       2.098319     1.914480
30       2.969012     2.602244
50       4.742269     3.968544
80       7.056089     5.925835
100      9.202390     7.302907
```