### PR TITLE
fix(ransac): fix number of threads which would compute the final mask

### DIFF
--- a/octreelib/ransac/cuda_ransac.py
+++ b/octreelib/ransac/cuda_ransac.py
@@ -149,7 +149,7 @@ class CudaRansac:
             for i in range(
                 block_start_indices[block_id] + thread_id,
                 block_start_indices[block_id] + block_sizes[block_id],
-                CUDA_THREADS,
+                cuda.blockDim.x,
             ):
                 if measure_distance(best_plane, point_cloud[i]) < threshold:
                     result_mask[i] = True


### PR DESCRIPTION
`THREADS_NUMBER` is incorrect because this number of threads may not be initialized. The correct number is `cuda.blockDim.x`