### PR TITLE
fix(ransac): remove redundant normalization

### DIFF
--- a/octreelib/ransac/util.py
+++ b/octreelib/ransac/util.py
@@ -19,11 +19,8 @@ def measure_distance(plane, point):
     :param plane: Plane coefficients.
     :param point: Point coordinates.
     """
-    return (
-        math.fabs(
-            plane[0] * point[0] + plane[1] * point[1] + plane[2] * point[2] + plane[3]
-        )
-        / (plane[0] ** 2 + plane[1] ** 2 + plane[2] ** 2) ** 0.5
+    return math.fabs(
+        plane[0] * point[0] + plane[1] * point[1] + plane[2] * point[2] + plane[3]
     )
 
 


### PR DESCRIPTION
Additional normalisation is removed because _normals_ are already _normalised_ when calculating the plane
```
Clouds   Old (s)     New (s)
10      1.126165    0.921498
20      1.914480    1.098207
30      2.602244    1.459543
50      3.968544    2.153955
80      5.925835    3.119089
100     7.302907    4.139988
```